### PR TITLE
Core: Extend Pixel experience Blacklist For Google Photos

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -713,7 +713,10 @@ public class ApplicationPackageManager extends PackageManager {
         String packageName = ActivityThread.currentPackageName();
         if (packageName != null &&
                 packageName.contains("com.google.android.apps.photos") &&
-                name.contains("PIXEL_2021_EXPERIENCE")) {
+                name.contains("PIXEL_2021_EXPERIENCE") ||
+                name.contains("PIXEL_2021_MIDYEAR_EXPERIENCE") ||
+                name.contains("PIXEL_2020_EXPERIENCE") ||
+                name.contains("PIXEL_2020_MIDYEAR_EXPERIENCE")) {
             return false;
         }
         return mHasSystemFeatureCache.query(new HasSystemFeatureQuery(name, version));


### PR DESCRIPTION
Turns out having these brakes Original quality backups.
Since these indicate that the device is pixel 4 with in the turn brakes device spoofing as OG pixel

Change-Id: I336facff7b55552f094997ade337656461a0ea1d
Signed-off-by: Joey Huab <joey@evolution-x.org>